### PR TITLE
ci: publish to npm using trusted publishing

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -13,6 +13,11 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-**'
   pull_request: {}
 
+permissions:
+  id-token: write # Required for publishing with OIDC
+  contents: write # Required for creating releases
+  pages: write # Required for deploying to GitHub Pages
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -112,11 +117,6 @@ jobs:
       matrix:
         node-version: [22]
 
-    permissions:
-      contents: write
-      pages: write
-      id-token: write
-
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -154,11 +154,7 @@ jobs:
           fi
 
       - name: Publish package to npm
-        env:
-          TAG: ${{ steps.extract_release.outputs.TAG }}
-        run: |
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm publish
+        run: npm publish ${{ steps.extract_release.outputs.TAG }}
 
       - name: Create Github Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Replace the long-lived `NPM_TOKEN` secret with npm's OIDC-based **trusted publishing**, matching the recent changes in [node-coap-client](https://github.com/AlCalzone/node-coap-client) and [waddle](https://github.com/zwave-js/waddle).

## Changes

- **Add top-level `permissions` block** with `id-token: write`, `contents: write`, and `pages: write`
- **Remove `NPM_TOKEN` secret usage** — no more `npm config set //registry.npmjs.org/:_authToken=...`
- **Simplify `npm publish` step** — a single `npm publish` command that passes the dist-tag for pre-releases
- **Remove job-level permissions** (now inherited from workflow-level)

## How it works

The workflow requests a signed JWT from GitHub's OIDC endpoint (`id-token: write`). npm exchanges this token for a short-lived, scoped publish token — no stored secrets needed.

## Prerequisites

The npm package must have **Trusted Publishing** configured on [npmjs.com](https://npmjs.com) to trust this repository and workflow. This is a one-time setup in the npm package settings UI.