### PR TITLE
chore: update GitHub Actions to latest versions and use Node.js 24

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -23,14 +23,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [24]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -50,14 +50,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [24]
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -79,12 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
 
       - name: Install dependencies
@@ -94,10 +94,10 @@ jobs:
         run: npm run build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [24]
 
     environment:
       name: github-pages
@@ -123,10 +123,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -157,7 +157,7 @@ jobs:
         run: npm publish ${{ steps.extract_release.outputs.TAG }}
 
       - name: Create Github Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Node.js 20 is deprecated on GitHub Actions runners (removal in Fall 2026), and several actions had new major versions available. This updates the CI workflow to stay current and avoid future breakage.

### Changes

Updates all GitHub Actions in `test-and-release.yml` to their latest major versions and bumps the Node.js version from 22 to 24:

- `actions/checkout`: v4 -> v7
- `actions/setup-node`: v4 -> v6
- `actions/configure-pages`: v5 -> v6
- `actions/upload-pages-artifact`: v3 -> v5
- `softprops/action-gh-release`: v2 -> v3
- `actions/deploy-pages`: v4 (already latest)
- `node-version`: 22 -> 24

### Breaking changes review

None of the breaking changes in the updated actions affect this workflow:

- **checkout v7** blocks fork PR checkout in `pull_request_target`/`workflow_run` triggers -- we only use `push` and `pull_request`.
- **upload-pages-artifact v5** removed the `name` input and outputs -- we use neither.
- **action-gh-release v3** only changed the Node runtime from 20 to 24, no API changes.